### PR TITLE
Add nuspec file for nuget package for GoIO SDK

### DIFF
--- a/nuget/GoIO.SDK.nuspec
+++ b/nuget/GoIO.SDK.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>GoIO.SDK</id>
+        <version>1.0.6</version>
+        <title>GoIO Software Development Kit</title>
+        <authors>Vernier Software &amp; Technology</authors>
+        <licenseUrl>https://github.com/VernierSoftwareTechnology/GoIO_SDK/blob/master/license.txt</licenseUrl>
+        <projectUrl>https://github.com/VernierSoftwareTechnology/GoIO_SDK</projectUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <description>The GoIO SDK is intended to provide software developers with the ability to access Vernier Software &amp; Technology Go! devices from their own applications. Supported devices include the Go! Motion detector, the Go! Temp thermometer, the Vernier Mini Gc, and the Go! Link sensor interface, which can connect to a variety of analog sensors.</description>
+        <summary>The GoIO SDK is intended to provide software developers with the ability to access Vernier Software &amp; Technology Go! devices from their own applications.</summary>
+        <copyright>Copyright (C) 2014 Vernier Software &amp; Technology. All rights reserved.</copyright>
+        <language>en-US</language>
+        <tags>GoIO Vernier</tags>
+    </metadata>
+    <files>
+        <file src="build\GoIO.SDK.targets" target="build\GoIO.SDK.targets" />
+        <file src="..\redist\GoIO_DLL\dotNet\GoIOdotNET.dll" target="lib\net20\GoIOdotNET.dll" />
+        <file src="..\redist\GoIO_DLL\dotNet\GoIOdotNET.pdb" target="lib\net20\GoIOdotNET.pdb" />
+        <file src="..\redist\GoIO_DLL\dotNet\GoIOdotNET.XML" target="lib\net20\GoIOdotNET.XML" />
+        <file src="..\redist\VSTCoreDefsdotNET\VSTCoreDefsdotNET.dll" target="lib\net20\VSTCoreDefsdotNET.dll" />
+        <file src="..\redist\VSTCoreDefsdotNET\VSTCoreDefsdotNET.pdb" target="lib\net20\VSTCoreDefsdotNET.pdb" />
+        <file src="..\redist\VSTCoreDefsdotNET\VSTCoreDefsdotNET.XML" target="lib\net20\VSTCoreDefsdotNET.XML" />
+        <file src="..\redist\GoIO_DLL\Win32\GoIO_DLL.dll" target="native\x86\GoIO_DLL.dll" />
+        <file src="..\redist\GoIO_DLL\Win64\GoIO_DLL.dll" target="native\x64\GoIO_DLL.dll" />
+    </files>
+</package>

--- a/nuget/build/GoIO.SDK.targets
+++ b/nuget/build/GoIO.SDK.targets
@@ -1,0 +1,27 @@
+<!--
+***********************************************************************************************
+This file includes the native GoIO dlls so they are available at runtime.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <GoIODllPath Condition=" '$(GoIODllPath)' == '' ">$(MSBuildThisFileDirectory)..\native\$(Platform)\GoIO_DLL.dll</GoIODllPath>
+  </PropertyGroup>  
+
+  <Target Name="CopyGoIONativeReference">
+    <!-- Make sure the platform has been set appropriately before trying to copy the native reference. -->
+    <Error Code="LH0001" Text="The project platform must be set to x86 or x64. Please change your target platform and try again." Condition=" !Exists('$(GoIODllPath)') " 
+           File="$(MSBuildProjectFile)"/>
+    
+    <Copy SourceFiles="$(GoIODllPath)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true"/>
+  </Target>
+
+  <PropertyGroup>
+    <AfterBuildDependsOn>
+      CopyGoIONativeReference;
+    </AfterBuildDependsOn>
+  </PropertyGroup>
+  
+  <Target Name="AfterBuild" DependsOnTargets="$(AfterBuildDependsOn)"/>
+</Project>

--- a/nuget/readme.txt
+++ b/nuget/readme.txt
@@ -1,0 +1,11 @@
+To update the nuget package for GoIO.SDK, update the package version # in the .nuspec file, run "nuget pack" on it, and then upload the package to nuget.org.  Easy!
+
+You can install NuGet from http://docs.nuget.org/docs/start-here/installing-nuget
+
+Using the command line tool, the command to create the package is:
+
+nuget pack GoIO.SDK.nuspec
+
+This will create a file named GoIO.SDK.<version>.nupkg, where version is the version # from the .nuspec file
+
+P.S. don't forget to commit the change to the .nuspec file for the version #


### PR DESCRIPTION
This change adds a .nuspec file which creates a .nupkg which can be
uploaded to nuget.org.  A .NET developer can use the nuget package to
easily add references to the GoIO SDK.

For this pull request, please review the package metadata at https://www.nuget.org/packages/GoIO.SDK/.  In particular, I set the Copyright and Authors fields to Vernier Software, though I am the owner because I uploaded the package.  Please also try adding the package as a reference in VS using the NuGet package manager.  You'll see that I require you to accept the license, as I assumed you'd want that.

The .targets file is used to update a Visual Studio project file to
automatically copy the native GoIO dlls so they are available at
runtime.

The readme contains notes and instructions for updating the nuget
package.

The nuget package is available online at
https://www.nuget.org/packages/GoIO.SDK/1.0.6

The version number is 1.0.6 because it took me six tries before I was
able to get the package to work correctly.
